### PR TITLE
Add basic filters to the Listings queryset

### DIFF
--- a/base/filters.py
+++ b/base/filters.py
@@ -1,0 +1,10 @@
+from django_filters import rest_framework as filters
+
+
+class NumberInFilter(filters.BaseInFilter, filters.NumberFilter):
+    """Filters based on the logic:
+
+    "If the number is in this set of numbers: 1,2,3". Behaves identically
+    to BaseInFilter except enforces Number type.
+    """
+    pass

--- a/base/tests/__init__.py
+++ b/base/tests/__init__.py
@@ -1,0 +1,21 @@
+import urllib
+
+from model_bakery import baker
+from rest_framework.test import APITestCase
+
+
+class TestHelpers:
+    """Useful testing helper functions."""
+
+    @staticmethod
+    def make_user(*args, **kwargs):
+        user = baker.make('auth.User', *args, **kwargs)
+        return user
+
+    @staticmethod
+    def add_query_params(path, **kwargs):
+        return path + '?' + urllib.parse.urlencode(kwargs)
+
+
+class SubletSharkAPITestCase(APITestCase, TestHelpers):
+    pass

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -1,7 +1,6 @@
 """Views for the institutions app."""
 
 from rest_framework import viewsets
-from rest_framework.response import Response
 
 from institutions.models import Institution
 from institutions.serializers import InstitutionSerializer

--- a/listings/baker_recipes.py
+++ b/listings/baker_recipes.py
@@ -1,12 +1,18 @@
 import datetime
 
-from model_bakery.recipe import Recipe
+from model_bakery.recipe import Recipe, foreign_key
 
+from listings.models.listing import AccommodationType
 
 ListingRecipe = Recipe(
     'listings.Listing',
-    address='132 Marshall Street',
-    accommodation_type=1,
+    address='132 Marshall Street, Waterloo, Ontario, N2J4E6',
+    accommodation_type=AccommodationType.APARTMENT,
     start_date=datetime.date(2050, 1, 1),
     end_date=datetime.date(2050, 4, 30),
+)
+
+RoomRecipe = Recipe(
+    'listings.Room',
+    listing=foreign_key(ListingRecipe),
 )

--- a/listings/filters.py
+++ b/listings/filters.py
@@ -1,0 +1,39 @@
+"""Filter classes for the listings app."""
+from django import forms
+from django_filters import rest_framework as filters
+
+from base.filters import NumberInFilter
+from listings.models import Listing
+
+
+class ListingFilter(filters.FilterSet):
+    start_date = filters.DateFilter(
+        field_name='start_date',
+        lookup_expr='gte',
+    )
+    end_date = filters.DateFilter(
+        field_name='end_date',
+        lookup_expr='lte',
+    )
+    ensuite = filters.BooleanFilter(
+        field_name='rooms__ensuite',
+        lookup_expr='exact',
+    )
+    minifridge = filters.BooleanFilter(
+        field_name='rooms__minifridge',
+        lookup_expr='exact',
+    )
+    bed_type = NumberInFilter(
+        field_name='rooms__bed_type',
+        lookup_expr='in',
+    )
+
+    class Meta:
+        model = Listing
+        fields = [
+            'start_date',
+            'end_date',
+            'ensuite',
+            'minifridge',
+            'bed_type',
+        ]

--- a/listings/models/listing.py
+++ b/listings/models/listing.py
@@ -30,10 +30,10 @@ class Listing(UUIDMixin):
         help_text=_('The type of building the listing is for.')
     )
     start_date = DateField(
-        help_text=_('The first date that the subletter may move in.')
+        help_text=_('The first day that the subletter may move in.')
     )
     end_date = DateField(
-        help_text=_('The date by which the subletter must leave.')
+        help_text=_('The day by which the subletter must leave.')
     )
     address = CharField(
         max_length=255,

--- a/listings/tests.py
+++ b/listings/tests.py
@@ -99,7 +99,6 @@ class ListingsViewSetTestCase(SubletSharkAPITestCase):
         super().setUp()
         self.url = reverse('listings:listings-list')
         self.client.force_authenticate(user=self.user)
-        self.url = reverse('listings:listings-list')
         self.first_listing = baker.make_recipe(
             'listings.ListingRecipe',
             start_date=datetime.date(2019, 12, 31),

--- a/listings/tests.py
+++ b/listings/tests.py
@@ -2,11 +2,18 @@ import datetime
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.urls import reverse
 
 from model_bakery import baker
+from rest_framework import status
+
+from base.tests import TestHelpers, SubletSharkAPITestCase
+from listings.models.listing import AccommodationType
+from listings.models.room import BedType
 
 
 class ListingTestCase(TestCase):
+    """Tests for the Listings model."""
 
     def setUp(self):
         self.listing = baker.make_recipe('listings.ListingRecipe')
@@ -78,3 +85,147 @@ class ListingTestCase(TestCase):
             self.listing.start_date = datetime.date(2020, 1, 1)
             self.listing.end_date = datetime.date(2020, 1, 15)
             self.listing.save(update_fields=['start_date', 'end_date'])
+
+
+class ListingsViewSetTestCase(SubletSharkAPITestCase):
+    """Tests for the listings view set."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = cls.make_user()
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('listings:listings-list')
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('listings:listings-list')
+        self.first_listing = baker.make_recipe(
+            'listings.ListingRecipe',
+            start_date=datetime.date(2019, 12, 31),
+            end_date=datetime.date(2020, 4, 29),
+        )
+        self.second_listing = baker.make_recipe(
+            'listings.ListingRecipe',
+            start_date=datetime.date(2020, 1, 1),
+            end_date=datetime.date(2020, 4, 30),
+            accommodation_type=AccommodationType.APARTMENT,
+        )
+        self.rooms = [
+            baker.make_recipe(
+                'listings.RoomRecipe',
+                listing=self.second_listing
+            )
+            for _ in range(5)
+        ]
+
+    def test_start_date_filter(self):
+        """Test that listings before start_date are not returned, and listings
+        after start_date are.
+        """
+        response = self.client.get(
+            self.add_query_params(self.url, start_date='2020-01-01')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Ensure only the second listing was returned.
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['id'], str(self.second_listing.id))
+
+    def test_end_date_filter(self):
+        """Test that the listings that end after end_date are not returned,
+        and listings that end before end_date are.
+        """
+        response = self.client.get(
+            self.add_query_params(self.url, end_date='2020-04-29')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Ensure only the first listing was returned.
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['id'], str(self.first_listing.id))
+
+    def test_ensuite_filter(self):
+        """Test that the listings whose rooms that match the query are
+        returned.
+        """
+        # Case 1: None of the rooms for the listing have an ensuite, should
+        # return 0 listings.
+        response = self.client.get(
+            self.add_query_params(self.url, ensuite=True)
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 0)
+        # Case 2: Any number of the rooms for a listing have an ensuite, should
+        # return those listings.
+        self.rooms[0].ensuite = True
+        self.rooms[0].save()
+        response = self.client.get(
+            self.add_query_params(self.url, ensuite=True)
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 1)
+
+    def test_minifridge_filter(self):
+        """Test that the listings which have rooms that match the query are
+        returned.
+        """
+        # Case 1: None of the rooms for the listing have a minifridge, should
+        # return 0 listings.
+        response = self.client.get(
+            self.add_query_params(self.url, minifridge=True)
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 0)
+        # Case 2: Any number of the rooms for a listing have an ensuite, should
+        # return those listings.
+        self.rooms[3].minifridge = True
+        self.rooms[3].save()
+        response = self.client.get(
+            self.add_query_params(self.url, minifridge=True)
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 1)
+
+    def test_bed_type_filter(self):
+        """Test that the listings which have any rooms that match the bed
+        type query are returned.
+        """
+        # Case 1: None of the rooms for the listing have a king bed, should
+        # return 0 listings.
+        response = self.client.get(
+            self.add_query_params(self.url, bed_type=f'{BedType.KING}')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 0)
+        # Case 2: All of the rooms have single beds, should return 1 listing.
+        response = self.client.get(
+            self.add_query_params(self.url, bed_type=f'{BedType.SINGLE}')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 1)
+        # Case 3: Combination of bed types should return 1 listing if any of
+        # them are valid.
+        self.rooms[0].bed_type = BedType.DOUBLE
+        self.rooms[0].save()
+        self.rooms[1].bed_type = BedType.QUEEN
+        self.rooms[1].save()
+        response = self.client.get(
+            self.add_query_params(self.url, bed_type=f'{BedType.DOUBLE}')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 1)
+        response = self.client.get(
+            self.add_query_params(self.url, bed_type=f'{BedType.KING},'
+                                                     f'{BedType.DOUBLE}')
+        )
+        response_json = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_json), 1)

--- a/listings/urls.py
+++ b/listings/urls.py
@@ -6,9 +6,9 @@ from rest_framework import routers
 from listings.views import ListingViewSet
 
 router = routers.DefaultRouter()
-router.register(r'listings', ListingViewSet, basename='listing')
+router.register(r'listings', ListingViewSet, basename='listings')
 
 
 urlpatterns = [
-    path('', include(router.urls))
+    path('', include((router.urls, 'listings'), namespace='listings'))
 ]

--- a/listings/views.py
+++ b/listings/views.py
@@ -2,14 +2,15 @@
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
+from listings.filters import ListingFilter
 from listings.models import Listing
 from listings.serializers import ListingSerializer
 
 
 class ListingViewSet(viewsets.ModelViewSet):
     """ViewSet for the Listing model."""
-    queryset = Listing.objects.all().prefetch_related('images')
+    queryset = Listing.objects.all().prefetch_related('images').distinct()
     serializer_class = ListingSerializer
     permission_classes = [IsAuthenticated]
+    filter_class = ListingFilter

--- a/listings/views.py
+++ b/listings/views.py
@@ -13,4 +13,4 @@ class ListingViewSet(viewsets.ModelViewSet):
     queryset = Listing.objects.all().prefetch_related('images').distinct()
     serializer_class = ListingSerializer
     permission_classes = [IsAuthenticated]
-    filter_class = ListingFilter
+    filterset_class = ListingFilter

--- a/subletshark/settings.py
+++ b/subletshark/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS').split(' ')
 INSTALLED_APPS = [
     'institutions',
     'listings',
+    'django_filters',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -115,7 +116,10 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+    ],
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
     ]
 }
 


### PR DESCRIPTION
This change introduces django_filters for the returned
set of listings. Listings will be filtered based on the
query parameters passed, for example:

/listings/listings/?start_date=2020-01-01 will only return
listings whose start dates occur on a date greater than or
equal to January 1, 2020.

New filters:
start_date (Date in format: YYYY-MM-DD): Listings whose start date occurs
  on a date greater than or equal to the given date.
end_date (Date in format: YYYY-MM-DD): Listings whose end date occurs
  before or on the given date.
ensuite (Boolean):  Listings which have at least 1 room that has an ensuite.
minifridge (Boolean): Listings which have at least 1 room that has
  a minifridge.
bed_type (list(numbers)): Listings which have at least 1 room that has
  at least one of the provided bed types.

This change also adds some testing helpers for running tests against our
API as an authenticated user.